### PR TITLE
Refactored these to remove all classes. Classes aren't needed here, f…

### DIFF
--- a/ProofpointSIEM2Humio_Config.py
+++ b/ProofpointSIEM2Humio_Config.py
@@ -4,12 +4,13 @@ import logging
 #Set Logging Level and file name
 pfpt_log_level = logging.DEBUG
 log_file = 'PFPT_SIEMapi2Humio.log'
+last_successful_time_File = 'last_success_time'
 
 #Code version - do not alter
 pfpt_version = '1.0'
 
 #####Proofpoint API Config Information
-SIEM_API_url = 'https://tap-api-v2.proofpoint.com/v2/siem/all?format=json&sinceSeconds=3600'
+SIEM_API_url = 'https://tap-api-v2.proofpoint.com/v2/siem/all'
 SIEM_API_user_name = ''
 SIEM_API_password = ''
 
@@ -22,11 +23,17 @@ HumioHECurl = Humio_base+'/api/v1/ingest/hec/raw'
 HumioHECContent_pfpt  = "{'Content-Type': 'application/json', 'Accept':'application/json'}"
 HumioHECverify = False
 
-#Humio HEC Token for Clicks Permitted events
-HumioHECtoken_pfpt_ClicksPermitted = ''
-#Humio HEC Token for Clicks Blocked events
-HumioHECtoken_pfpt_ClicksBlocked = ''
-#Humio HEC Token for Messages Delivered events
-HumioHECtoken_pfpt_MessagesDelivered = ''
-#Humio HEC Token for Messages Blocked events
-HumioHECtoken_pfpt_MessagesBlocked = ''
+# Token Mapping
+HumioHECTokens = {
+    #Humio HEC Token for Clicks Permitted events
+    'clicksPermitted': '',
+
+    #Humio HEC Token for Clicks Blocked events
+    'clicksBlocked': '',
+
+    #Humio HEC Token for Messages Delivered events
+    'messagesDelivered': '',
+    
+    #Humio HEC Token for Messages Blocked events
+    'messagesBlocked': ''
+}

--- a/ProofpointSIEM2Humio_Main.py
+++ b/ProofpointSIEM2Humio_Main.py
@@ -2,82 +2,86 @@
 
 #python imports
 import requests
-import base64
+from requests.auth import HTTPBasicAuth
+import json
 import logging
 import sys
 
 #local imports
 import ProofpointSIEM2Humio_Config as config
-from Send2HumioHEC import Send_to_HEC as humio
+from Send2HumioHEC import send_to_HEC
 
-class PFPT_SIEM_2_Humio():
+def get_last_query_time(filename=config.last_successful_time_File):
+    with open(filename) as file:
+        return file.read().strip()
 
-    def get_PFPT_SIEM(self):
+def set_last_query_time(time):
+    with open(config.last_successful_time_File, "w") as file:
+        file.write(time)
 
-        #get version from config file and configure logging
-        version = config.pfpt_version
-        log_level = config.pfpt_log_level
-        logging.basicConfig(filename=config.log_file, filemode='a+', format='%(asctime)s - %(name)s - %(levelname)s - %(message)s', level=log_level)
+def main():
 
-        logging.info('PFPTSIEM2Humio v' + version + ' : Starting data collection process')
+    #get version from config file and configure logging
+    version = config.pfpt_version
+    log_level = config.pfpt_log_level
+    logging.basicConfig(filename=config.log_file, filemode='a+', format='%(asctime)s - %(name)s - %(levelname)s - %(message)s', level=log_level)
+
+    logging.info('PFPTSIEM2Humio v' + version + ' : Starting data collection process')
+    
+    #construct API call
+    logging.info('PFPTSIEM2Humio v' + version + ' : Constructing API call')
+    basicAuth = HTTPBasicAuth(config.SIEM_API_user_name, config.SIEM_API_password)
+
+    #attempt to contact PFPT SIEM API
+    logging.info('PFPTSIEM2Humio v' + version + ' : Making API call to Proofpoint SIEM API')
+
+    SIEM_API_params = {
+        "format": "json", # should return 'queryEndTime'
+        "sinceTime": get_last_query_time() 
+    }
+    try: 
+        response = requests.get(config.SIEM_API_url, auth=basicAuth, params=SIEM_API_params)
+        response_code = str(response.status_code)
+        pfpt_response = response.json()
+        logging.info('PFPTSIEM2Humio v' + version + ' : Call to the Proofpoint SIEM API response code was = ' + response_code)
+    
+    except Exception as e:
+        logging.info('PFPTSIEM2Humio v' + version + ' : Call to the Proofpoint SIEM API response code was = ' + response_code)
+        logging.error('PFPTSIEM2Humio v' + version + ' : Error contacting the Proofpoint SIEM API = ' + e.message + '  ' + e.args)
+        sys.exit('PFPTSIEM2Humio v' + version + ' : Unable to collect Proofpoint data, please correct any issues and try again')
+
+    for event_type in ['clicksPermitted', 'clicksBlocked', 'messagesDelivered', 'messagesBlocked']:
+        events = pfpt_response[event_type]
+        num_events = str(len(events))
+
+        if not events:
+            logging.info('PFPTSIEM2Humio v' + version + ' : No events of type ' + str(event_type) + ' to send...')    
+            continue
+
+        logging.info('PFPTSIEM2Humio v' + version + ' : Preparing to send ' + num_events + ' ' + str(event_type) + ' Events to Humio')
+
+        # Humio/Crowdstrike LogScale can accept a newline delimited list of json objects. 
+        # Therefore you can send all events at once instead of 1 at a time.
+        to_send = "\n".join(json.dumps(event) for event in events)
         
-        #construct API call
-        logging.info('PFPTSIEM2Humio v' + version + ' : Constructing API call')
-        userAndPass = config.SIEM_API_user_name + ':' + config.SIEM_API_password
-        b64val = base64.b64encode(userAndPass.encode()).decode()
-        headers = {'Authorization' : 'Basic %s' %  b64val}
-        payload = {}
+        logging.info('PFPTSIEM2Humio v' + version + ' ' +event_type +' HEC: Sending data to Humio HEC')
 
-        #attempt to contact PFPT SIEM API
-        logging.info('PFPTSIEM2Humio v' + version + ' : Making API call to Proofpoint SIEM API')
-        try: 
-            response = requests.get(config.SIEM_API_url, headers=headers, data=payload)
-            response_code = str(response.status_code)
-            pfpt_response = response.json()
-            logging.info('PFPTSIEM2Humio v' + version + ' : Call to the Proofpoint SIEM API response code was = ' + response_code)
-        
-        except Exception as e:
-            logging.info('PFPTSIEM2Humio v' + version + ' : Call to the Proofpoint SIEM API response code was = ' + response_code)
-            logging.error('PFPTSIEM2Humio v' + version + ' : Error contacting the Proofpoint SIEM API = ' + e.message + '  ' + e.args)
-            sys.exit('PFPTSIEM2Humio v' + version + ' : Unable to collect Proofpoint data, please correct any issues and try again')
+        HECToken = config.HumioHECTokens[event_type]
+        try:
+            r = send_to_HEC(to_send, HECToken)
+            transmit_result = r.status_code
+            logging.debug('PFPTSIEM2Humio v' + version + ' ' +event_type +' HEC: Transmission status code for data push to HEC= '+ str(transmit_result))
+
+        except requests.exceptions.RequestException as e:
+            error=str(e)
+            logging.info('PFPTSIEM2Humio v' + version + ' ' +event_type +' HEC: Unable to evaluate and transmit sensor_data event: Error: ' + error)
+            sys.exit('PFPTSIEM2Humio v' + version + ' ' +event_type +' HEC: This is fatal error, please review and correct the issue - CrowdStrike Intel Indicators to Humio is shutting down')
+
+        logging.info('PFPTSIEM2Humio v' + version + ' ' +event_type +' HEC: Sent ' + num_events + ' ' + event_type + ' events to Humio for processing')
+
+    # Set last query time after everything is sent
+    set_last_query_time(pfpt_response['queryEndTime'])
 
 
-        pfpt_clicksPermitted = pfpt_response['clicksPermitted']  
-        pfpt_clicksBlocked = pfpt_response['clicksBlocked']
-        pfpt_messagesDelivered = pfpt_response['messagesDelivered']
-        pfpt_messagesBlocked = pfpt_response['messagesBlocked'] 
-
-        #evaluate and send clicks permitted events
-        if len(pfpt_clicksPermitted) > 0:
-            num_cp = str(len(pfpt_clicksPermitted))
-            logging.info('PFPTSIEM2Humio v' + version + ' : Preparing to send ' + num_cp + ' ClicksPermitted Events to Humio')
-            for cp in pfpt_clicksPermitted:
-                event_type = 'ClicksPermitted'
-                humio.send_to_HEC(cp, event_type)
-
-        #evaluate and send clicks blocker events
-        if len(pfpt_clicksBlocked) > 0:
-            num_cb = str(len(pfpt_clicksBlocked))
-            logging.info('PFPTSIEM2Humio v' + version + ' : Preparing to send ' + num_cb + ' ClicksBlocked Events to Humio')
-            for cb in pfpt_clicksBlocked:
-                event_type = 'ClicksBlocked'
-                humio.send_to_HEC(cb, event_type, num_cb)
-
-        #evaluate and send messagesDelivered events
-        if len(pfpt_messagesDelivered) > 0:
-            num_md = str(len(pfpt_messagesDelivered))
-            logging.info('PFPTSIEM2Humio v' + version + ' : Preparing to send ' + num_md + ' MessagesDelivered Events to Humio')
-            for md in pfpt_messagesDelivered:
-                event_type = 'MessagesDelivered'
-                humio.send_to_HEC(md, event_type, num_md)
-
-        #evaluate and send messagesBlocked events
-        if len(pfpt_messagesBlocked) > 0:
-            num_mb = str(len(pfpt_messagesBlocked))
-            logging.info('PFPTSIEM2Humio v' + version + ' : Preparing to send ' + num_mb + ' MessagesBlocked Events to Humio')
-            for mb in pfpt_messagesBlocked:
-                event_type = 'MessagesBlocked'
-                humio.send_to_HEC(mb, event_type, num_mb)
-
-pfpt=PFPT_SIEM_2_Humio()
-pfpt.get_PFPT_SIEM()
+if __name__ == "__main__":
+    main()

--- a/Send2HumioHEC.py
+++ b/Send2HumioHEC.py
@@ -1,52 +1,15 @@
 #!/usr/bin/env python
 
 import requests
-import logging
-import sys
 
 #local imports
 import ProofpointSIEM2Humio_Config as config
 
-class Send_to_HEC():
+def send_to_HEC(event_data, HumioHECToken):
 
-    def send_to_HEC(event_data, event_type, num_events):
+    HumioHECurl = config.HumioHECurl
+    HumioHECcontent = config.HumioHECContent_pfpt
+    HumioHECverify = config.HumioHECverify
 
-        HumioHECurl = config.HumioHECurl
-        HumioHECcontent = config.HumioHECContent_pfpt
-        HumioHECverify = config.HumioHECverify
-        log_level = config.pfpt_log_level
-
-        version = config.pfpt_version
-        logging.basicConfig(filename=config.log_file, filemode='a+', format='%(asctime)s - %(name)s - %(levelname)s - %(message)s', level=log_level)
-        
-        logging.info('PFPTSIEM2Humio v' + version + ' ' +event_type +' HEC: Sending data to Humio HEC')
-
-        if event_type == 'ClicksPermitted':
-            HumioHECtoken =config.HumioHECtoken_pfpt_ClicksPermitted
-        
-        elif event_type == 'ClicksBlocked':
-            HumioHECtoken =config.HumioHECtoken_pfpt_ClicksBlocked
-
-        elif event_type == 'MessagesDelivered':
-            HumioHECtoken =config.HumioHECtoken_pfpt_MessagesDelivered
-        
-        elif event_type == 'MessagesBlocked':
-            HumioHECtoken =config.HumioHECtoken_pfpt_MessagesBlocked
-
-
-        try:
-            header = {"Authorization": "Bearer " + HumioHECtoken, "Content-Type": HumioHECcontent} 
-            r = requests.post(url=HumioHECurl, headers=header, json=event_data, verify=HumioHECverify, timeout=300)
-            transmit_result = r.status_code
-            logging.debug('PFPTSIEM2Humio v' + version + ' ' +event_type +' HEC: Transmission status code for data push to HEC= '+ str(transmit_result))
-            logging.debug('PFPTSIEM2Humio v' + version + ' ' +event_type +' HEC: Transmission results for data push to HEC= '+ str(r.json))
-
-        except requests.exceptions.RequestException as e:
-            error=str(e)
-            logging.info('PFPTSIEM2Humio v' + version + ' ' +event_type +' HEC: Unable to evaluate and transmit sensor_data event: Error: ' + error)
-            try:
-                sys.exit('PFPTSIEM2Humio v' + version + ' ' +event_type +' HEC: This is fatal error, please review and correct the issue - CrowdStrike Intel Indicators to Humio is shutting down')
-            except:
-                pass
-
-        logging.info('PFPTSIEM2Humio v' + version + ' ' +event_type +' HEC: Sent ' + num_events + ' ' + event_type + ' events to Humio for processing')
+    header = {"Authorization": "Bearer " + HumioHECToken, "Content-Type": HumioHECcontent} 
+    return requests.post(url=HumioHECurl, headers=header, data=event_data, verify=HumioHECverify, timeout=300)


### PR DESCRIPTION
Refactored these to remove all classes. Classes aren't needed here, functions will work just fine.

Send2HumioHEC.py: I removed all logging and moved that over to the main function so this is a more pure function

ProofpointSIEM2Humio_Main: Removed the if statements since we can combine those using the event_types and a loop. Also, this is using the requests.auth.HTTPBasicAuth to create the SIEM API authentication method. This now combines all of the events into a newline delimited list of json objects since Humio can handles data pushes as such.

I also add a way to persist the last time the query sent data for. hardcoding the sinceSeconds=3600 was inflexible so this script can now be installed and run via cron or a timer and will pick up contiguous data

ProofpointSIEM2Humio_Config.py: removed the hardcode params to the SIEM API. Also mapped the tokens for each event_type to make it easier to call